### PR TITLE
Configurable external urls

### DIFF
--- a/src/main/java/io/github/sridharbandi/AxeRunner.java
+++ b/src/main/java/io/github/sridharbandi/AxeRunner.java
@@ -39,6 +39,11 @@ public class AxeRunner implements IRunner {
         return this;
     }
 
+    public AxeRunner setScriptURL(String url) {
+      params.setScriptURL(url);
+      return this;
+    }
+
     @Override
     public Issues execute() throws IOException {
         return (Issues) a11y.execute(Engine.AXE, params);

--- a/src/main/java/io/github/sridharbandi/HtmlCsRunner.java
+++ b/src/main/java/io/github/sridharbandi/HtmlCsRunner.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 public class HtmlCsRunner implements IRunner {
-
+  
     private A11y a11y;
     private HTMLCS standard;
     private Params params;
@@ -35,6 +35,11 @@ public class HtmlCsRunner implements IRunner {
     public HtmlCsRunner setPageTile(String pageTitle) {
         params.setPageTitle(pageTitle);
         return this;
+    }
+
+    public HtmlCsRunner setScriptUrl(String url) {
+      params.setScriptURL(url);
+      return this;
     }
 
     @Override

--- a/src/main/java/io/github/sridharbandi/HtmlCsRunner.java
+++ b/src/main/java/io/github/sridharbandi/HtmlCsRunner.java
@@ -37,7 +37,7 @@ public class HtmlCsRunner implements IRunner {
         return this;
     }
 
-    public HtmlCsRunner setScriptUrl(String url) {
+    public HtmlCsRunner setScriptURL(String url) {
       params.setScriptURL(url);
       return this;
     }

--- a/src/main/java/io/github/sridharbandi/modal/htmlcs/Params.java
+++ b/src/main/java/io/github/sridharbandi/modal/htmlcs/Params.java
@@ -13,6 +13,7 @@ public class Params {
     String pageTitle;
     Map<String, AxeRuleOptions> rules;
     List<String> tags;
+    String scriptURL;
 
     public Params(){
         this.rules = new HashMap<>();
@@ -41,6 +42,14 @@ public class Params {
 
     public void setPageTitle(String pageTitle) {
         this.pageTitle = pageTitle;
+    }
+
+    public String getScriptURL() {
+      return scriptURL;
+    }
+    
+    public void setScriptURL(String scriptURL) {
+      this.scriptURL = scriptURL;
     }
 
     public Map<String, AxeRuleOptions> getRules() {

--- a/src/main/resources/js/axe.js
+++ b/src/main/resources/js/axe.js
@@ -1,6 +1,6 @@
 async function axeData(params) {
 	const obj = JSON.parse(params);
-	await injectAxeScript();
+	await injectAxeScript(obj.scriptURL);
 	var rules = obj.rules;
 	var tags = obj.tags;
 	var results = await runAxe(tags, rules);
@@ -92,10 +92,10 @@ function runAxe(tags, rules) {
 	});
 }
 
-function injectAxeScript() {
+function injectAxeScript(scriptURL) {
 	return new Promise((resolve, reject) => {
 		const script = document.createElement('script');
-		script.src = "https://cdn.jsdelivr.net/npm/axe-core@latest/axe.min.js";
+		script.src = scriptURL ?? "https://cdn.jsdelivr.net/npm/axe-core@latest/axe.min.js";
 		script.addEventListener('load', resolve);
 		script.addEventListener('error', e => reject(e.error));
 		document.head.appendChild(script);

--- a/src/main/resources/js/htmlcs.js
+++ b/src/main/resources/js/htmlcs.js
@@ -2,7 +2,7 @@ async function getData(params) {
     const obj = JSON.parse(params);
     const codes = obj.ignoreCodes;
 
-    await injectScript();
+    await injectScript(obj.scriptURL);
     const results = await runHtmlCS(obj.standard, codes);
     const pageTitle = obj.pageTitle == null ? document.title : obj.pageTitle;
     return {
@@ -31,10 +31,10 @@ function getFormattedDate() {
     return formattedDate;
 }
 
-function injectScript() {
+function injectScript(scriptURL) {
     return new Promise((resolve, reject) => {
         const script = document.createElement('script');
-        script.src = "https://squizlabs.github.io/HTML_CodeSniffer/build/HTMLCS.js";
+        script.src = scriptURL ?? "https://squizlabs.github.io/HTML_CodeSniffer/build/HTMLCS.js";
         script.addEventListener('load', resolve);
         script.addEventListener('error', e => reject(e.error));
         document.head.appendChild(script);

--- a/src/test/java/io/github/sridharbandi/util/A11yTest.java
+++ b/src/test/java/io/github/sridharbandi/util/A11yTest.java
@@ -31,6 +31,8 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.matches;
 
 @ExtendWith(MockitoExtension.class)
 public class A11yTest {
@@ -47,6 +49,16 @@ public class A11yTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
+    }
+    
+    @Test
+    public void testScriptUrlConfiguration() throws IOException {
+      when(javascriptExecutor.executeScript("return document.readyState")).thenReturn("complete");
+      Params params = new Params();
+      String alternativeScriptURL = "https://my-other-script-url";
+      params.setScriptURL(alternativeScriptURL);
+      a11y.execute(Engine.AXE, params);
+      verify(javascriptExecutor).executeScript(matches(String.format("axeData\\(.*\"scriptURL\":\"%s\".*\\)", alternativeScriptURL)));
     }
 
     @Test


### PR DESCRIPTION
Hi,

first of all, thank you for making working with AXE and HtmlCS so easy.

We run accessibility-tests within our new build-environment which does not have access to the internet. Therefore we would like to get the js-scripts from another server. I made the urls configurable, defaulting to the current behavior.

Kind regards
Torsten