### PR TITLE
Update Java 11 and Selenium 4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,13 +34,13 @@
     </scm>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <freemaker.version>2.3.31</freemaker.version>
         <slf4j.version>2.0.3</slf4j.version>
         <junit.version>5.9.1</junit.version>
         <mockito.verion>4.8.1</mockito.verion>
-        <selenium.version>4.5.3</selenium.version>
+        <selenium.version>4.10.0</selenium.version>
         <jackson.version>2.14.0-rc3</jackson.version>
         <commonsio.version>2.11.0</commonsio.version>
         <annotation.version>1.3.2</annotation.version>


### PR DESCRIPTION
We encountered a conflict with the test framework (currently Selenium 4.10) which is not compatible with the current Selenium version used in Java-a11y. 

In this commit, I updated the project's Java version from Java 8 to Java 11 and also upgraded Selenium to the latest available version. 

