### PR TITLE
[Update] Flatten nested "target" arrays in Axe results

### DIFF
--- a/src/main/resources/js/axe.js
+++ b/src/main/resources/js/axe.js
@@ -10,6 +10,10 @@ async function axeData(params) {
 	results.device = device();
 	results.browser = getBrowser();
 	results.date = getFormattedDate();
+
+	flattenTargetArrays(results.violations);
+	flattenTargetArrays(results.incomplete);
+	flattenTargetArrays(results.inapplicable);
 	return results;
 }
 
@@ -100,4 +104,18 @@ function injectAxeScript(scriptURL) {
 		script.addEventListener('error', e => reject(e.error));
 		document.head.appendChild(script);
 	});
+}
+
+function flattenTargetArrays(resultsArray) {
+	if (Array.isArray(resultsArray)) {
+		resultsArray.forEach(result => {
+			if (result.nodes && Array.isArray(result.nodes)) {
+				result.nodes.forEach(node => {
+					if (node.target && Array.isArray(node.target)) {
+						node.target = node.target.flat();
+					}
+				});
+			}
+		});
+	}
 }


### PR DESCRIPTION
Fix [issues/30](https://github.com/sridharbandi/Java-a11y/issues/30). This PR updates the axeData function to flatten the nested arrays in the "target" field for all rules and result types (violations, incomplete, and inapplicable) before returning the results. 